### PR TITLE
feat: Add mobile connect script for one-tap Termius access

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,36 @@ Open your terminal, navigate to the project directory, and run the following com
     *Example:* `.\start_services.ps1 -PodIp 216.81.245.97 -PodPort 11114`
 
 After running the script, it will compile the `llama-server` if needed, start all services on the remote pod, and provide you with the final `ssh` commands to paste into a new terminal to access the model.
+
+---
+
+## Mobile Access with Termius (One-Tap Launch)
+
+For a seamless mobile experience, you can use the `mobile_connect.sh` script to launch and connect to the pod with a single tap in an SSH client like Termius.
+
+### One-Time Setup in Termius
+
+1.  **Create a New Host:**
+    *   **Alias:** `Vesper Pod`
+    *   **Hostname:** Your Pod's IP Address (e.g., `216.81.245.97`)
+    *   **Port:** Your Pod's SSH Port (e.g., `11114`)
+    *   **Username:** `root`
+    *   **Password:** Your Pod's Password
+
+2.  **Create a Snippet:**
+    *   Go to the "Snippets" section in Termius.
+    *   Create a new snippet with the following content:
+        ```bash
+        cd /workspace/runpod-babylegs && ./mobile_connect.sh <YOUR_POD_IP> <YOUR_POD_PORT>
+        ```
+    *   **Important:** Replace `<YOUR_POD_IP>` and `<YOUR_POD_PORT>` with your actual pod credentials.
+
+3.  **Link Snippet to Host:**
+    *   Go back to the Host you created.
+    *   Under the "Startup Snippet" option, select the snippet you just created.
+
+### Launching the Connection
+
+Now, simply tap on the "Vesper Pod" host in Termius. It will automatically connect, run the startup script, and establish the SSH tunnel.
+
+Once the script finishes (you'll see a message "SSH tunnel is now active"), you can open a browser on your phone and navigate to `http://localhost:8080` to interact with the model. The Termius session must remain active in the background.

--- a/mobile_connect.sh
+++ b/mobile_connect.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+# ==============================================================================
+# Mobile Connect Script for Vesper AI Pod
+#
+# Description:
+# This script is designed for a one-tap launch from a mobile SSH client like
+# Termius. It connects to the remote pod, ensures all services are running,
+# and establishes a persistent SSH tunnel to the main LLM server.
+#
+# This allows you to interact with the model from your mobile browser at
+# http://localhost:8080 after running.
+#
+# Usage (in Termius or any SSH client):
+# ./mobile_connect.sh <YOUR_POD_IP> <YOUR_POD_PORT>
+#
+# Example:
+# ./mobile_connect.sh 216.81.245.97 11114
+# ==============================================================================
+
+# --- Argument Validation ---
+if [ "$#" -ne 2 ]; then
+    echo "❌ Error: Missing arguments."
+    echo "Usage: $0 <POD_IP> <POD_PORT>"
+    exit 1
+fi
+
+POD_IP=$1
+POD_PORT=$2
+
+# --- Remote Configuration ---
+# This is the local port on your mobile device that will be forwarded.
+LOCAL_PORT="8080"
+# This is the port the llama-server is listening on inside the pod.
+REMOTE_PORT="8080"
+# Path to the remote launcher script on the pod.
+REMOTE_SCRIPT_PATH="/workspace/runpod-babylegs/start_remote_services.sh"
+
+# --- Main Execution ---
+echo "🚀 Initiating mobile connection to Vesper..."
+echo "This will start remote services and create an SSH tunnel."
+echo "Once connected, access the model at http://localhost:$LOCAL_PORT on your device's browser."
+echo "Press Ctrl+C in this terminal to close the connection."
+
+# Connect, execute the remote script, and establish the port forward.
+# -L: Forwards the local port to the remote port.
+# -N: Do not execute a remote command (after the initial script runs). This keeps the tunnel open.
+# -t: Force pseudo-terminal allocation to run the remote script.
+ssh -L "$LOCAL_PORT:127.0.0.1:$REMOTE_PORT" "root@$POD_IP" -p "$POD_PORT" -t "bash $REMOTE_SCRIPT_PATH"
+
+echo "✅ Connection closed."

--- a/start_remote_services.sh
+++ b/start_remote_services.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -e
+
+# ==============================================================================
+# Remote Services Launcher for Vesper AI Pod
+#
+# Description:
+# This script is executed remotely by another script (e.g., mobile_connect.sh).
+# It ensures that all necessary services (RAG server, LLM server) are running
+# on the pod. It is designed to be non-interactive.
+#
+# It handles auto-compilation of llama-server and runs the servers in the
+# background so that the SSH connection that started it can be used for
+# port-forwarding.
+# ==============================================================================
+
+# --- Path Configuration ---
+WORKSPACE_DIR="/workspace"
+REPO_DIR="$WORKSPACE_DIR/runpod-babylegs"
+VENV_PATH="$REPO_DIR/vesper_env/bin/activate"
+MODEL_PATH="${VESPER_MODEL_PATH:-$REPO_DIR/models/huihui-ai/Huihui-gpt-oss-120b-BF16-abliterated/Q4_K_M-GGUF/Q4_K_M-GGUF/Q4_K_M-GGUF-00001-of-00009.gguf}"
+RAG_SCRIPT_PATH="$REPO_DIR/build_memory.py"
+LLAMA_SERVER_PATH="$REPO_DIR/llama.cpp/build/bin/llama-server"
+LLAMA_CPP_DIR="$REPO_DIR/llama.cpp"
+
+# --- Service Port Configuration ---
+RAG_PORT="5000"
+LLAMA_PORT="8080"
+
+# --- LLM Parameter Configuration ---
+GPU_LAYERS=34
+CONTEXT_SIZE=1024
+
+# --- Log File Configuration ---
+RAG_LOG_FILE="$WORKSPACE_DIR/rag_server.log"
+LLAMA_LOG_FILE="$WORKSPACE_DIR/llama_server.log"
+
+# --- Function to check if a process is running on a given port ---
+is_running() {
+  if lsof -i -P -n | grep -q ":$1 (LISTEN)"; then
+    return 0 # 0 means true in bash
+  else
+    return 1
+  fi
+}
+
+# --- Main Execution ---
+echo "--- Remote Service Check ---"
+
+# Activate Python environment
+echo "🐍 Activating Python environment..."
+source "$VENV_PATH"
+
+# Auto-compile llama-server if it doesn't exist
+if [ ! -f "$LLAMA_SERVER_PATH" ]; then
+  echo "🛠️ 'llama-server' not found. Compiling now..."
+  cd "$LLAMA_CPP_DIR"
+  make
+  echo "✅ Compilation complete."
+  cd "$REPO_DIR" # Return to the repo directory
+fi
+
+# Check and start RAG Memory Server
+if is_running $RAG_PORT; then
+  echo "🧠 RAG Memory Server is already running."
+else
+  echo "🧠 Starting RAG Memory Server in the background..."
+  nohup python3 "$RAG_SCRIPT_PATH" > "$RAG_LOG_FILE" 2>&1 &
+fi
+
+# Check and start Main LLM Server
+if is_running $LLAMA_PORT; then
+  echo "🧠 Main LLM Server is already running."
+else
+  echo "🧠 Launching Main LLM Server in the background..."
+  nohup "$LLAMA_SERVER_PATH" \
+    --model "$MODEL_PATH" \
+    --n-gpu-layers $GPU_LAYERS \
+    --ctx-size $CONTEXT_SIZE \
+    --host 0.0.0.0 \
+    --port $LLAMA_PORT > "$LLAMA_LOG_FILE" 2>&1 &
+fi
+
+echo "✅ Remote services are running."
+echo "-----------------------------------------------------"
+# This final message is to let the user of mobile_connect.sh know it's safe to proceed.
+echo "SSH tunnel is now active. You can connect to http://localhost:$LLAMA_PORT"
+echo "This terminal window will now idle to keep the connection alive. Press Ctrl+C to close."
+# The 'sleep infinity' is a simple way to keep the script (and thus the SSH session) alive.
+sleep infinity


### PR DESCRIPTION
This commit introduces a seamless, one-tap solution for connecting to and launching the Vesper AI pod from a mobile device using an SSH client like Termius.

Key changes:
- Adds `mobile_connect.sh`, a new entry point script designed for mobile clients. It handles argument parsing and establishes a persistent SSH tunnel for the LLM server.
- Adds `start_remote_services.sh`, a robust script that runs on the remote pod. It checks for running services, starts them if needed (RAG and LLM servers), and auto-compiles `llama-server` if it's not found. This script is designed to be idempotent and non-interactive.
- Updates `README.md` with a new "Mobile Access with Termius" section, providing clear, step-by-step instructions for a one-time setup to achieve a one-tap launch experience.

This solution directly addresses the user's goal of having a mobile-friendly way to interact with the model without needing a PC, multiple terminals, or manual port forwarding commands.